### PR TITLE
cloud-redis: basic service design + implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val root = project
     core,
     firestore,
     pubsub,
-    storage
+    storage,
+    redis
   )
 
 lazy val core = project
@@ -98,6 +99,21 @@ lazy val storage = project
       "dev.zio"                %% "zio"                     % "1.0.0-RC18-2",
       "dev.zio"                %% "zio-interop-guava"       % "28.2.0.1",
       "com.google.cloud"       % "google-cloud-storage"     % "1.108.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
+    )
+  )
+  .enablePlugins(BuildInfoPlugin)
+
+lazy val redis = project
+  .in(file("modules/redis"))
+  .dependsOn(core)
+  .settings(stdSettings("zio-gcp-redis"))
+  .settings(buildInfoSettings("zio.gcp.redis"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio"                %% "zio"                     % "1.0.0-RC18-2",
+      "dev.zio"                %% "zio-interop-guava"       % "28.2.0.1",
+      "com.google.cloud"       % "google-cloud-redis"       % "1.0.0",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
     )
   )

--- a/modules/redis/src/main/scala/zio/gcp/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/gcp/redis/Redis.scala
@@ -1,0 +1,37 @@
+package zio.gcp.redis
+
+import com.google.cloud.redis.v1.GetInstanceRequest
+import zio._
+import com.google.cloud.redis.v1.CloudRedisSettings
+import com.google.cloud.redis.v1.Instance
+import com.google.cloud.redis.v1.CloudRedisClient
+
+object Redis {
+  trait Service {
+    def getInstance(request: GetInstanceRequest): Task[Instance]
+    def getSettings: Task[CloudRedisSettings]
+    def isShutDown: Task[Boolean]
+    def isTerminated: Task[Boolean]
+  }
+
+  def live: Layer[Throwable, Redis] =
+    ZLayer.fromManaged {
+
+      val acquire = IO.effect(CloudRedisClient.create())
+      val release = (cloudRedisClient: CloudRedisClient) => IO.effect(cloudRedisClient.close()).orDie
+
+      Managed.make(acquire)(release).map { cloudRedisClient =>
+        new Service {
+          def getInstance(request: GetInstanceRequest): Task[Instance] = Task(cloudRedisClient.getInstance(request))
+
+          def getSettings: Task[CloudRedisSettings] = Task(cloudRedisClient.getSettings())
+
+          def isShutDown: Task[Boolean] = Task(cloudRedisClient.isShutdown())
+
+          def isTerminated: Task[Boolean] = Task(cloudRedisClient.isTerminated())
+
+        }
+      }
+    }
+
+}

--- a/modules/redis/src/main/scala/zio/gcp/redis/package.scala
+++ b/modules/redis/src/main/scala/zio/gcp/redis/package.scala
@@ -1,0 +1,17 @@
+package zio.gcp
+
+import zio.{ Has, RIO }
+import com.google.cloud.redis.v1.GetInstanceRequest
+import com.google.cloud.redis.v1.CloudRedisSettings
+import com.google.cloud.redis.v1.Instance
+
+package object redis {
+
+  type Redis = Has[Redis.Service]
+
+  def getInstance(request: GetInstanceRequest): RIO[Redis, Instance] = RIO.accessM(_.get.getInstance(request))
+  def getSettings: RIO[Redis, CloudRedisSettings]                    = RIO.accessM(_.get.getSettings)
+  def isShutDown: RIO[Redis, Boolean]                                = RIO.accessM(_.get.isShutDown)
+  def isTerminated: RIO[Redis, Boolean]                              = RIO.accessM(_.get.isTerminated)
+
+}


### PR DESCRIPTION
@mijicd there is more to this API than what I have ported over as a zio client. However, those methods on the API are dangerous (ie can delete a running cloud redis instance). The main purpose of this client is to be able to query information about a running cloud redis client e.g.

```java
  private Instance() {
    name_ = "";
    displayName_ = "";
    locationId_ = "";
    alternativeLocationId_ = "";
    redisVersion_ = "";
    reservedIpRange_ = "";
    host_ = "";
    currentLocationId_ = "";
    state_ = 0;
    statusMessage_ = "";
    tier_ = 0;
    authorizedNetwork_ = "";
    persistenceIamIdentity_ = "";
    connectMode_ = 0;
  }
```

The other methods, if there is a demand, can be reviewed later and included in some safe way if needed.